### PR TITLE
chore: spotless plugin can only run with java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,15 +134,18 @@ jacocoTestReport {
 wrapper {
     gradleVersion = '5.6.2'
 }
-
-spotless {
-    java {
-        target fileTree(projectDir) {
-            include 'src/main/**/*.java'
-            exclude '**/build/**'
+if(JavaVersion.current() == JavaVersion.VERSION_1_8){
+    spotless {
+        java {
+            target fileTree(projectDir) {
+                include 'src/main/**/*.java'
+                exclude '**/build/**'
+            }
+            googleJavaFormat('1.1').aosp()
         }
-        googleJavaFormat('1.1').aosp()
     }
+}else{
+    throw new Exception("Spotless must be run with java 8")
 }
 
 task formatCode(dependsOn: ['licenseFormat','spotlessApply'])


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

What changes are being made?
Setup gradle to run spotless plugin only with java 8, because it doesn't work with other versions.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
