### PR TITLE
chore: remove throw statement if spotless is not run on java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,8 +144,6 @@ if(JavaVersion.current() == JavaVersion.VERSION_1_8){
             googleJavaFormat('1.1').aosp()
         }
     }
-}else{
-    throw new Exception("Spotless must be run with java 8")
 }
 
 task formatCode(dependsOn: ['licenseFormat','spotlessApply'])


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

What changes are being made? 
Remove `throw` statement so it doesn't interrupt other gradle tasks.  
<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
