### PR TITLE
refactor: make abstract instance method public

### DIFF
--- a/src/main/java/org/arkecosystem/crypto/transactions/builder/AbstractTransactionBuilder.java
+++ b/src/main/java/org/arkecosystem/crypto/transactions/builder/AbstractTransactionBuilder.java
@@ -73,5 +73,5 @@ public abstract class AbstractTransactionBuilder<
 
     public abstract Transaction getTransactionInstance();
 
-    abstract TBuilder instance();
+    public abstract TBuilder instance();
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

What changes are being made?
Changed `abstract TBuilder instance();` to `public abstract TBuilder instance();`

Why are these changes necessary? 
This makes it possible to extend `AbstractTransactionBuilder`

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
