### PR TITLE
feat: added option to add custom deserializer classes to Deserializer

### DIFF
--- a/src/main/java/org/arkecosystem/crypto/transactions/Deserializer.java
+++ b/src/main/java/org/arkecosystem/crypto/transactions/Deserializer.java
@@ -112,13 +112,6 @@ public class Deserializer {
         return signatureLength;
     }
 
-    //    public void setNewTypeGroup(int typeGroup, HashMap<Integer, Transaction> transactionTypes) {
-    //        this.transactionGroups.put(typeGroup, transactionTypes);
-    //    }
-    //
-    //    public void setNewType(int typeGroup, int type, Transaction transaction){
-    //        this.transactionGroups.get(typeGroup).put(type,transaction);
-    //    }
 
     public void setNewTransactionType(Transaction transaction) {
         if (this.transactionGroups.containsKey(transaction.getTransactionTypeGroup())) {

--- a/src/main/java/org/arkecosystem/crypto/transactions/Deserializer.java
+++ b/src/main/java/org/arkecosystem/crypto/transactions/Deserializer.java
@@ -112,7 +112,6 @@ public class Deserializer {
         return signatureLength;
     }
 
-
     public void setNewTransactionType(Transaction transaction) {
         if (this.transactionGroups.containsKey(transaction.getTransactionTypeGroup())) {
             this.transactionGroups

--- a/src/test/java/org/arkecosystem/crypto/transactions/deserializers/DeserializerTest.java
+++ b/src/test/java/org/arkecosystem/crypto/transactions/deserializers/DeserializerTest.java
@@ -1,0 +1,59 @@
+package org.arkecosystem.crypto.transactions.deserializers;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.gson.internal.LinkedTreeMap;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import org.arkecosystem.crypto.transactions.Deserializer;
+import org.arkecosystem.crypto.transactions.FixtureLoader;
+import org.arkecosystem.crypto.transactions.types.Transaction;
+import org.junit.jupiter.api.Test;
+
+class DeserializerTest {
+    @Test
+    void checkNewTransactionTypeShouldBeTrue() {
+        LinkedTreeMap<String, Object> fixture =
+                FixtureLoader.load("transactions/v2-ecdsa/transfer-sign");
+
+        Deserializer deserializer = new Deserializer(fixture.get("serialized").toString());
+        deserializer.setNewTransactionType(
+                new Transaction() {
+                    @Override
+                    public byte[] serialize() {
+                        return new byte[0];
+                    }
+
+                    @Override
+                    public void deserialize(ByteBuffer buffer) {}
+
+                    @Override
+                    public int getTransactionType() {
+                        return 1;
+                    }
+
+                    @Override
+                    public int getTransactionTypeGroup() {
+                        return 2;
+                    }
+
+                    @Override
+                    public HashMap<String, Object> assetToHashMap() {
+                        return null;
+                    }
+                });
+
+        assertTrue(deserializer.hasTransactionType(2, 1));
+    }
+
+    @Test
+    void checkNewTransactionTypeShouldBeFalse() {
+        LinkedTreeMap<String, Object> fixture =
+                FixtureLoader.load("transactions/v2-ecdsa/transfer-sign");
+
+        Deserializer deserializer = new Deserializer(fixture.get("serialized").toString());
+
+        assertFalse(deserializer.hasTransactionType(2, 1));
+    }
+}

--- a/src/test/java/org/arkecosystem/crypto/transactions/deserializers/DeserializerTest.java
+++ b/src/test/java/org/arkecosystem/crypto/transactions/deserializers/DeserializerTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 class DeserializerTest {
     @Test
-    void checkNewTransactionTypeShouldBeTrue() {
+    void checkNewTransactionType() {
         LinkedTreeMap<String, Object> fixture =
                 FixtureLoader.load("transactions/v2-ecdsa/transfer-sign");
 
@@ -45,15 +45,42 @@ class DeserializerTest {
                 });
 
         assertTrue(deserializer.hasTransactionType(2, 1));
+        assertFalse(deserializer.hasTransactionType(2, 2));
+        assertFalse(deserializer.hasTransactionType(3, 1));
+
     }
 
     @Test
-    void checkNewTransactionTypeShouldBeFalse() {
+    void checkNewTransactionToCoreGroup() {
         LinkedTreeMap<String, Object> fixture =
-                FixtureLoader.load("transactions/v2-ecdsa/transfer-sign");
+            FixtureLoader.load("transactions/v2-ecdsa/transfer-sign");
 
         Deserializer deserializer = new Deserializer(fixture.get("serialized").toString());
+        deserializer.setNewTransactionType(
+            new Transaction() {
+                @Override
+                public byte[] serialize() {
+                    return new byte[0];
+                }
 
-        assertFalse(deserializer.hasTransactionType(2, 1));
+                @Override
+                public void deserialize(ByteBuffer buffer) {}
+
+                @Override
+                public int getTransactionType() {
+                    return 11;
+                }
+
+                @Override
+                public int getTransactionTypeGroup() {
+                    return 1;
+                }
+
+                @Override
+                public HashMap<String, Object> assetToHashMap() {
+                    return null;
+                }
+            });
+        assertTrue(deserializer.hasTransactionType(1, 11));
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

What changes are being made? 
Added option to add custom deserializer classes to Deserializer

Why are these changes necessary? 
With this option, it is possible to test custom transactions deserializer.

How were these changes implemented? 
Added two new public methods to `Deserialzer` class

`public void setNewTransactionType(Transaction transaction)`
`public boolean hasTransactionType(int typeGroup, int type)`
## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
